### PR TITLE
重定义CURVE_SM2等常量值, 避免与IPSec国际标准冲突

### DIFF
--- a/src/libstrongswan/crypto/diffie_hellman.c
+++ b/src/libstrongswan/crypto/diffie_hellman.c
@@ -43,7 +43,6 @@ ENUM_NEXT(diffie_hellman_group_names, MODP_1024_160, CURVE_448, ECP_521_BIT,
 	"ECP_384_BP",
 	"ECP_512_BP",
 	"CURVE_25519",
-	"CURVE_SM2",
 	"CURVE_448");
 ENUM_NEXT(diffie_hellman_group_names, MODP_NULL, MODP_NULL, CURVE_448,
 	"MODP_NULL");
@@ -54,7 +53,9 @@ ENUM_NEXT(diffie_hellman_group_names, NTRU_112_BIT, NTRU_256_BIT, MODP_NULL,
 	"NTRU_256");
 ENUM_NEXT(diffie_hellman_group_names, NH_128_BIT, NH_128_BIT, NTRU_256_BIT,
 	"NEWHOPE_128");
-ENUM_NEXT(diffie_hellman_group_names, MODP_CUSTOM, MODP_CUSTOM, NH_128_BIT,
+ENUM_NEXT(diffie_hellman_group_names, CURVE_SM2, CURVE_SM2, NH_128_BIT,
+	"CURVE_SM2");
+ENUM_NEXT(diffie_hellman_group_names, MODP_CUSTOM, MODP_CUSTOM, CURVE_SM2,
 	"MODP_CUSTOM");
 ENUM_END(diffie_hellman_group_names, MODP_CUSTOM);
 

--- a/src/libstrongswan/crypto/diffie_hellman.h
+++ b/src/libstrongswan/crypto/diffie_hellman.h
@@ -62,8 +62,7 @@ enum diffie_hellman_group_t {
 	ECP_384_BP    = 29,
 	ECP_512_BP    = 30,
 	CURVE_25519   = 31,
-	CURVE_SM2     = 32,
-	CURVE_448     = 33,
+	CURVE_448     = 32,
 	/** insecure NULL diffie hellman group for testing, in PRIVATE USE */
 	MODP_NULL = 1024,
 	/** MODP group with custom generator/prime */
@@ -73,6 +72,8 @@ enum diffie_hellman_group_t {
 	NTRU_192_BIT = 1032,
 	NTRU_256_BIT = 1033,
 	NH_128_BIT   = 1040,
+	/** Custom SM2 Curve group defined locally, in PRIVATE USE */
+	CURVE_SM2 = 1050,
 	/** internally used DH group with additional parameters g and p, outside
 	 * of PRIVATE USE (i.e. IKEv2 DH group range) so it can't be negotiated */
 	MODP_CUSTOM = 65536,


### PR DESCRIPTION
1. In IPSec standard, CURVE_448 is defined as 32. We should follow the existing standards and re-define the value of CURVE_SM2.

(我计划后续分批上传更多的变更内容)