### PR TITLE
 Fix sm4 cbc decrypt failed when in and out buf address is same. Fix load sm2 private key failed.

### DIFF
--- a/src/libcharon/plugins/vici/vici_cred.c
+++ b/src/libcharon/plugins/vici/vici_cred.c
@@ -233,6 +233,10 @@ CALLBACK(load_key, vici_message_t*,
 	{
 		type = KEY_BLISS;
 	}
+	else if (strcaseeq(str, "sm2"))
+	{
+		type = KEY_SM2;
+	}
 	else
 	{
 		return create_reply("invalid key type: %s", str);

--- a/src/libstrongswan/plugins/gmalg/gmalg/sm4.c
+++ b/src/libstrongswan/plugins/gmalg/gmalg/sm4.c
@@ -257,17 +257,17 @@ void sm4_cbc_encrypt(sm4_ctx *ctx, u8 *key, u8 *iv, u8 *in, u8 len, u8 *out)
 #if DEBUG
 	printf(" function: %s ,  line= %d \n", __FUNCTION__, __LINE__);
 #endif
-	u8 temp[16];
 	int i;
 
 	sm4_set_key(ctx, key, 16);
-	memcpy(temp, iv, 16 );
 	while(len > 0)
 	{
 		for(i = 0; i < 16; i++)
-			out[i] = (u8)(in[i] ^ temp[i]);
+		{
+			out[i] = (u8)(in[i] ^ iv[i]);
+		}
 		sm4_one_round(ctx->sk_enc, out, out);
-		memcpy(temp, out, 16);
+		iv = out;
 		in  += 16;
 		out += 16;
 		len -= 16;
@@ -280,18 +280,34 @@ void sm4_cbc_decrypt(sm4_ctx *ctx, u8 *key, u8 *iv, u8 *in, u8 len, u8 *out)
 	printf(" function: %s ,  line= %d \n", __FUNCTION__, __LINE__);
 #endif
 	u8 temp[16];
+	u8 temp_iv[16];
 	int i;
 
 	sm4_set_key(ctx, key, 16);
-	memcpy(temp, iv, 16 );
+	
 	while(len > 0)
 	{
+		if(in == out)
+		{
+			memcpy(temp, in, 16); /* /if in and out are same buf, bakup in as next iv. */
+		}
 		sm4_one_round(ctx->sk_dec, in, out);
 		for(i = 0; i < 16; i++)
-			out[i] = (u8)(out[i] ^ temp[i] );
-		memcpy(temp, in, 16);
+		{
+			out[i] = (u8)(out[i] ^ iv[i]);
+		}
+		if(in == out)
+		{
+			memcpy(temp_iv, temp, 16);
+			iv = temp_iv;
+		}
+		else
+		{
+			iv = in;
+		}
 		in  += 16;
 		out += 16;
 		len -= 16;
 	}
+
 }

--- a/src/swanctl/commands/load_creds.c
+++ b/src/swanctl/commands/load_creds.c
@@ -209,6 +209,9 @@ static bool load_key_anytype(load_ctx_t *ctx, char *path,
 		case KEY_BLISS:
 			loaded = load_key(ctx, path, "bliss", encoding);
 			break;
+		case KEY_SM2:
+			loaded = load_key(ctx, path, "sm2", encoding);
+			break;
 		default:
 			fprintf(stderr, "unsupported key type in '%s'\n", path);
 			break;
@@ -278,6 +281,7 @@ static bool determine_credtype(char *type, credential_type_t *credtype,
 		{ "ecdsa",			CRED_PRIVATE_KEY,		KEY_ECDSA,			},
 		{ "bliss",			CRED_PRIVATE_KEY,		KEY_BLISS,			},
 		{ "pkcs12",			CRED_CONTAINER,			CONTAINER_PKCS12,	},
+		{ "sm2", 			CRED_PRIVATE_KEY, 		KEY_SM2,			},
 	};
 	int i;
 


### PR DESCRIPTION
解决issue中的“initiate failed: establishing CHILD_SA 'host-host' failed”问题，这个问题的原因是SM4 CBC解密时，in和out地址相同，导致解密失败。
并且顺便解决了，load sm2 private key报错的问题